### PR TITLE
Elevate design with branded hero and preserved features

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Lato&family=Lexend+Deca:wght@100..900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@500;700&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles/main.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"></script>
 </head>
@@ -22,7 +22,7 @@
         <div class="green-section" aria-hidden="true"></div>
         <div class="white-section" aria-hidden="true"></div>
         <header>
-            <img src="assets/logo_text.png" alt="databryan Logo" class="logo">
+            <img src="assets/databryan_logo_text.png" alt="databryan Logo" class="logo">
             <div class="language-selector">
                 <button id="language-button" class="language-button">
                     <img src="assets/flags/united-kingdom.png" alt="English" id="selected-flag">
@@ -43,6 +43,11 @@
             </div>
         </header>
         <main>
+            <section class="hero-content">
+                <h1 class="hero-title">From Data Chaos to AI-Ready</h1>
+                <p class="hero-subtitle">Efficient, scalable data engineering for AI readiness.</p>
+                <a href="#" class="hero-button">Book Free AI Readiness Call</a>
+            </section>
             <div class="typing-container" aria-label="Terminal-style text animation">
                 <p id="typing-text">🚀 [databryan]:~$ </p>
                 <span id="cursor" class="cursor"></span>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -16,7 +16,12 @@ document.addEventListener('DOMContentLoaded', () => {
           duration: 2,
           opacity: 1,
           scale: 1.05,
-          ease: "power3.easeOut"  
+          ease: "power3.easeOut"
+      }, "-=1.5")
+      .to(".hero-content", {
+          duration: 2,
+          opacity: 1,
+          ease: "power2.inOut"
       }, "-=1.5")
       .to(".typing-container", {
           duration: 2,
@@ -95,7 +100,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initial typing animation for default language
     const changeBackgroundColor = () => {
         document.body.style.transition = 'background-color 2s';
-        document.body.style.backgroundColor = '#072c71';
+        document.body.style.backgroundColor = '#F7F9FC';
     };
 
     setTimeout(changeBackgroundColor, 1000);

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,30 +1,19 @@
 :root {
-    --primary-bg-color: #020128;
-    --secondary-bg-color: #110c6c;
-    --text-color: #edf2f1;
-    --accent-color: #4fdea3;
-    --cursor-color: #ceedcf;
-    --font-primary: "Lexend Deca", sans-serif;
-    --font-secondary: "Lato", sans-serif;
-    --font-terminal: 'Courier New', Courier, monospace;
-    --shadow-color: rgba(0, 0, 0, 0.3);
-    --container-bg-color: rgba(4, 4, 49, 0.3);
-    --container-border-color: rgba(4, 4, 49, 0.35);
+    --primary-bg-color: #F7F9FC;
+    --secondary-bg-color: #00B6B9;
+    --text-color: #1E1E1E;
+    --accent-color: #0078D4;
+    --cta-color: #FF6B35;
+    --cursor-color: var(--cta-color);
+    --font-primary: 'Poppins', sans-serif;
+    --font-secondary: 'Inter', sans-serif;
+    --font-terminal: 'Fira Code', monospace;
+    --shadow-color: rgba(0, 0, 0, 0.1);
+    --container-bg-color: rgba(255, 255, 255, 0.8);
+    --container-border-color: rgba(160, 174, 192, 0.35);
+    --neutral-color: #A0AEC0;
   }
   
-  .lexend-deca-header {
-    font-family: var(--font-primary);
-    font-optical-sizing: auto;
-    font-weight: 600;
-    font-style: normal;
-  }
-  
-  .lexend-deca-body {
-    font-family: var(--font-primary);
-    font-optical-sizing: auto;
-    font-weight: 400;
-    font-style: normal;
-  }
   
   body, html {
     margin: 0;
@@ -35,9 +24,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: linear-gradient(135deg, var(--primary-bg-color) 25%, var(--secondary-bg-color) 90%);
+    background-color: var(--primary-bg-color);
     color: var(--text-color);
-    font-family: var(--font-primary);
+    font-family: var(--font-secondary);
   }
   
   .background-container {
@@ -64,15 +53,15 @@
     background-color: var(--accent-color);
     clip-path: polygon(0 0, 70% 0, 0 70%);
   }
-  
+
   .white-section {
-    background-color: var(--text-color);
+    background-color: var(--secondary-bg-color);
     clip-path: polygon(100% 100%, 40% 100%, 100% 40%);
   }
   
   .logo {
     position: absolute;
-    top: 30%;
+    top: 10%;
     left: 50%;
     transform: translate(-50%, -50%);
     opacity: 0;
@@ -82,7 +71,7 @@
   
   .typing-container {
     position: absolute;
-    top: 45%;
+    top: 60%;
     left: 50%;
     transform: translateX(-50%);
     width: 80%;
@@ -92,10 +81,10 @@
     font-family: var(--font-terminal);
     font-size: 1.2rem;
     color: var(--accent-color);
-    background-color: rgba(4, 4, 49, 0.8);
+    background-color: var(--container-bg-color);
     border: 2px solid var(--accent-color);
     border-radius: 10px;
-    box-shadow: 0 0 20px rgba(79, 222, 163, 0.5);
+    box-shadow: 0 0 20px rgba(0, 120, 212, 0.4);
     opacity: 0;
     transition: opacity 0.5s ease, max-height 0.5s ease, padding 0.5s ease;
     max-height: 0;
@@ -181,7 +170,7 @@
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
     z-index: 1000;
     border-radius: 8px;
-    font-family: var(--font-primary);
+    font-family: var(--font-secondary);
     transition: opacity 0.3s ease;
   }
   
@@ -198,9 +187,48 @@
     height: 20px;
     margin-right: 8px;
   }
+
+  .hero-content {
+    position: absolute;
+    top: 30%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    color: var(--text-color);
+    opacity: 0;
+  }
+
+  .hero-title {
+    font-family: var(--font-primary);
+    font-size: 2.5rem;
+    color: var(--accent-color);
+    margin-bottom: 1rem;
+  }
+
+  .hero-subtitle {
+    font-family: var(--font-secondary);
+    font-size: 1.25rem;
+    color: var(--neutral-color);
+    margin-bottom: 1.5rem;
+  }
+
+  .hero-button {
+    display: inline-block;
+    background-color: var(--cta-color);
+    color: var(--primary-bg-color);
+    padding: 0.75rem 1.5rem;
+    border-radius: 8px;
+    font-family: var(--font-primary);
+    transition: background-color 0.3s ease;
+  }
+
+  .hero-button:hover {
+    background-color: var(--accent-color);
+  }
   
   .language-option:hover {
     background-color: var(--secondary-bg-color);
+    color: var(--primary-bg-color);
   }
   
   .hidden {
@@ -208,35 +236,43 @@
   }
   
   
-  @media (max-width: 767px) {
+@media (max-width: 767px) {
     .green-section {
       clip-path: polygon(0 0, 100% 0, 0 40%);
     }
-    
+
     .white-section {
       clip-path: polygon(100% 100%, 10% 100%, 100% 60%);
     }
-  
+
     .logo {
       width: 50%;
-      top: 30%;
+      top: 15%;
     }
-  
+
+    .hero-content {
+      top: 40%;
+    }
+
     .typing-container {
       width: 90%;
       font-size: 1rem;
-      top: 45%;
+      top: 70%;
     }
   }
-  
+
   @media (min-width: 768px) and (max-width: 1024px) {
     .logo {
       width: 50%;
-      top: 28%;
+      top: 10%;
     }
-  
+
+    .hero-content {
+      top: 35%;
+    }
+
     .typing-container {
-      top: 20%;
+      top: 60%;
       font-size: 1.0rem;
     }
   }


### PR DESCRIPTION
## Summary
- Restore original language selector and terminal animation while adopting Poppins, Inter, and Fira Code fonts
- Introduce a hero section with new tagline and CTA button styled in Azure Blue and CTA Orange
- Refresh global palette and layout for lighter backgrounds, responsive hero, and consistent component colors

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68ae1d82f39083338f0ad4f449897875